### PR TITLE
✨ TWEAK: wp updates and bump version

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: warengonzaga
 Donate link: https://warengonzaga.com/donate
 Tags: simple, basic, update, year, footer, shortcodes
-Requires at least: 5.0
-Tested up to: 5.9
+Requires at least: 2.8.0
+Tested up to: 6.0.3
 Requires PHP: 5.6
 Stable tag: 1.2.1
 License: GPLv3

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: simple, basic, update, year, footer, shortcodes
 Requires at least: 2.8.0
 Tested up to: 6.0.3
 Requires PHP: 5.6
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: GPLv3
 License URI: https://opensource.org/licenses/GPL-3.0
 


### PR DESCRIPTION
Closes #7 

The plugin works in 6.0.3, the latest version.

The `Requires at least` field can be lowered to 2.8.0 as both [add_shortcode](https://developer.wordpress.org/reference/functions/add_shortcode/) and [esc_html](https://developer.wordpress.org/reference/functions/esc_html/) were available at the time.